### PR TITLE
INVT-730 Resolve vulnerability issue with webpack 3

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -27,14 +27,15 @@
     "@babel/core": "^7.1.2",
     "@babel/preset-env": "^7.1.0",
     "babel-loader": "^8.0.4",
-    "copy-webpack-plugin": "^4.5.4",
+    "copy-webpack-plugin": "^4.6.0",
     "css-loader": "^0.28.11",
     "file-loader": "^2.0.0",
     "html-webpack-plugin": "^3.2.0",
     "style-loader": "^0.23.1",
     "url-loader": "^1.1.2",
-    "webpack": "^3.12.0",
-    "webpack-dev-server": "^2.11.3"
+    "webpack": "^4.28.4",
+    "webpack-cli": "^3.2.1",
+    "webpack-dev-server": "^3.1.14"
   },
   "dependencies": {
     "@leanix/reporting": "^0.3.0",

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -63,12 +63,12 @@ module.exports = {
     })
   ],
 
-	devServer: {
+  devServer: {
     // "disableHostCheck" added due to issue: https://github.com/webpack/webpack-dev-server/issues/1604
     // Fix should be done with: https://github.com/webpack/webpack-dev-server/pull/1608
     disableHostCheck: true,
-		headers: {
-			'Access-Control-Allow-Origin': '*'
-		}
-	}
+    headers: {
+      'Access-Control-Allow-Origin': '*'
+    }
+  }
 }

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -5,6 +5,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   entry: './src/index.js',
+  mode: 'development',
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'report.[chunkhash].js'
@@ -63,6 +64,9 @@ module.exports = {
   ],
 
 	devServer: {
+    // "disableHostCheck" added due to issue: https://github.com/webpack/webpack-dev-server/issues/1604
+    // Fix should be done with: https://github.com/webpack/webpack-dev-server/pull/1608
+    disableHostCheck: true,
 		headers: {
 			'Access-Control-Allow-Origin': '*'
 		}


### PR DESCRIPTION
Issue exists in webpack-dev-server < 3.1.11.

Link to vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2018-14732


Execute `npm audit` with node 10:
```
$ npm audit

                       === npm audit security report ===

found 0 vulnerabilities
 in 11036 scanned packages
```