### PR TITLE
ATL-264 Fix path resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@leanix/reporting-cli",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@leanix/reporting-cli",
-      "version": "1.0.0-beta.23",
+      "version": "1.0.0-beta.24",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leanix/reporting-cli",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "description": "Command line interface to develop custom reports for LeanIX EAM",
   "preferGlobal": true,
   "main": "./lib/app.js",

--- a/src/dev-starter.ts
+++ b/src/dev-starter.ts
@@ -3,6 +3,7 @@ import { spawn } from 'cross-spawn';
 import jwtDecode from 'jwt-decode';
 import * as _ from 'lodash';
 import opn from 'opn';
+import { join } from 'path';
 import { ApiTokenResolver } from './api-token-resolver';
 import { loadLxrConfig } from './file.helpers';
 import { LxrConfig } from './interfaces';
@@ -62,8 +63,11 @@ export class DevStarter {
 
     let projectRunning = false;
 
-    const serverProcess =
-      wpMajorVersion === 5 ? spawn('node_modules/.bin/webpack', ['serve', ...args]) : spawn('node_modules/.bin/webpack-dev-server', args);
+    const webpackCmd = join(
+      ...(wpMajorVersion === 5 ? ['node_modules', '.bin', 'webpack'] : ['node_modules', '.bin', 'webpack-dev-server'])
+    );
+
+    const serverProcess = wpMajorVersion === 5 ? spawn(webpackCmd, ['serve', ...args]) : spawn(webpackCmd, args);
 
     serverProcess.stdout.on('data', (data) => {
       console.log(data.toString());
@@ -97,7 +101,7 @@ export class DevStarter {
 
   private getCurrentWebpackMajorVersion(): Promise<number> {
     return new Promise((resolve) => {
-      const webpackVersion = spawn('node_modules/.bin/webpack', ['-v']);
+      const webpackVersion = spawn(join(...['node_modules', '.bin', 'webpack']), ['-v']);
       webpackVersion.stdout.on('data', (data) => {
         const output: string = data.toString();
         const matches = output.match(/(\d+)\.\d+\.\d+/);

--- a/src/file.helpers.spec.ts
+++ b/src/file.helpers.spec.ts
@@ -1,4 +1,4 @@
-import { loadCliConfig } from './file.helpers';
+import { defaultBuildCmd, defaultDistPath, loadCliConfig } from './file.helpers';
 import { PackageJson } from './interfaces';
 
 describe('File Helpers', () => {
@@ -7,8 +7,8 @@ describe('File Helpers', () => {
       const packageJson: PackageJson = {};
 
       expect(loadCliConfig(packageJson)).toEqual({
-        distPath: './dist',
-        buildCommand: './node_modules/.bin/webpack'
+        distPath: defaultDistPath,
+        buildCommand: defaultBuildCmd
       });
     });
 

--- a/src/file.helpers.ts
+++ b/src/file.helpers.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { join } from 'path';
 import { CliConfig, LxrConfig, PackageJson } from './interfaces';
 import { getProjectDirectoryPath } from './path.helpers';
 
@@ -17,11 +18,13 @@ export function loadPackageJson(): PackageJson {
   return readJsonFile(packageJsonPath);
 }
 
+export const defaultBuildCmd = join(...['.', 'node_modules', '.bin', 'webpack']);
+export const defaultDistPath = 'dist';
 export function loadCliConfig(packageJson = loadPackageJson()): CliConfig {
   const leanixReportingCli = packageJson.leanixReportingCli || {};
 
   return {
-    distPath: leanixReportingCli.distPath ?? './dist',
-    buildCommand: leanixReportingCli.buildCommand ?? './node_modules/.bin/webpack'
+    distPath: leanixReportingCli.distPath ?? defaultDistPath,
+    buildCommand: leanixReportingCli.buildCommand ?? defaultBuildCmd
   };
 }

--- a/src/template-extractor.ts
+++ b/src/template-extractor.ts
@@ -3,7 +3,7 @@ import { render } from 'ejs';
 import * as inquirer from 'inquirer';
 import { sync as mkdirpSync } from 'mkdirp';
 import * as fs from 'fs';
-import * as path from 'path';
+import { dirname, resolve } from 'path';
 import { getProjectDirectoryPath } from './path.helpers';
 
 export class TemplateExtractor {
@@ -14,7 +14,7 @@ export class TemplateExtractor {
 
   private extractTemplateDir(templateDir: string, baseTemplateDir: string, answers: inquirer.Answers) {
     fs.readdirSync(templateDir).forEach((file) => {
-      const filePath = path.resolve(templateDir, file);
+      const filePath = resolve(templateDir, file);
       const isDir = fs.lstatSync(filePath).isDirectory();
       if (isDir) {
         this.extractTemplateDir(filePath, baseTemplateDir, answers);
@@ -31,7 +31,7 @@ export class TemplateExtractor {
 
     const template = fs.readFileSync(sourcePath).toString('utf-8');
     const result = render(template, answers);
-    mkdirpSync(path.dirname(destPath));
+    mkdirpSync(dirname(destPath));
     fs.writeFileSync(destPath, result);
   }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
 import { readJsonFile } from './file.helpers';
 
-const packageJson = readJsonFile(join(__dirname, '../package.json'));
+const packageJson = readJsonFile(join(__dirname, '..', 'package.json'));
 export const version = packageJson['version'];


### PR DESCRIPTION
Some file paths were hardcoded using Unix backslash, this doesn't work in Windows environments.
Fixed those cases by using the `join` command provided by NodeJS api.