### PR TITLE
feat: Allow configurable hostname instead of localhost

### DIFF
--- a/src/dev-starter.ts
+++ b/src/dev-starter.ts
@@ -29,7 +29,7 @@ export class DevStarter {
 
   private async startLocalServer(config: LxrConfig, accessToken?: string): Promise<DevServerStartResult> {
     const port = config.localPort || 8080
-    const localhostUrl = `https://localhost:${port}`
+    const localhostUrl = `https://${config.localHostname || 'localhost'}:${port}`
     const urlEncoded = encodeURIComponent(localhostUrl)
     const host = `https://${config.host}`
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,29 +1,30 @@
 export interface LxrConfig {
-  host: string
-  workspace: string
-  apitoken: string
-  localPort?: string
-  proxyURL?: string
-  ssl?: {
-    cert: string
-    key: string
-  }
+	host: string;
+	workspace: string;
+	apitoken: string;
+	localPort?: string;
+	localHostname?: string;
+	proxyURL?: string;
+	ssl?: {
+		cert: string;
+		key: string;
+	};
 }
 
 export interface PackageJson {
-  name?: string
-  version?: string
-  author?: string
-  description?: string
-  documentationLink?: string
-  leanixReport?: {
-    id?: string
-    title?: string
-  }
-  leanixReportingCli?: Partial<CliConfig>
+	name?: string;
+	version?: string;
+	author?: string;
+	description?: string;
+	documentationLink?: string;
+	leanixReport?: {
+		id?: string;
+		title?: string;
+	};
+	leanixReportingCli?: Partial<CliConfig>;
 }
 
 export interface CliConfig {
-  distPath: string
-  buildCommand: string
+	distPath: string;
+	buildCommand: string;
 }


### PR DESCRIPTION
This PR extends the configuration options so that developers can define a custom hostname instead of being limited to localhost.

## Motivation:

- When developing locally, localhost is typically fine.
- However, in cloud-based development environments (e.g. GitHub Workspaces, Gitpod, or Codespaces), services are often exposed via externally accessible URLs.
- With this change, developers can override the default localhost hostname to match their environment.

## Changes introduced:
- Added configuration option for hostname.
- Default remains localhost for local setups.
- Developers can now specify an alternative hostname in their configuration (e.g. for GitHub Workspaces).

## Example usage:


```json
{
  "host": "leanix.leanix.net",
  "workspace": "",
  "apitoken": "{{API_KEY}}",
  "proxyURL": "",
  "localPort": "8080",
  "localHostname": "supercool-hostname.dev"
}

```

## Impact:
- No breaking changes.
- Local development workflows remain unchanged.
- Improved flexibility for cloud-based or remote development environments.