### PR TITLE
DEVX-649: fix(codeowners): replace leading dash with wildcard

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-- @leanix/team-compass
+* @leanix/team-compass


### PR DESCRIPTION
## Summary\n\n- Lines starting with `-` are not valid [CODEOWNERS syntax](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#syntax-exceptions)\n- This PR replaces the leading `-` with `*` (match all files) on affected lines\n\n## Test plan\n\n- [ ] Review the changed CODEOWNERS lines\n- [ ] Verify the intended owners are still correctly assigned after the change